### PR TITLE
Disable heading numbering in MyST project configuration

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -6,6 +6,13 @@ project:
   github: vhrique/anne_ptbr
   bibliography:
     - references.bib
+  numbering:
+    heading_1: false
+    heading_2: false
+    heading_3: false
+    heading_4: false
+    heading_5: false
+    heading_6: false
   exports:
     - format: pdf
       template: plain_latex_book


### PR DESCRIPTION
## Summary
Updated the MyST project configuration to disable automatic numbering for all heading levels (H1-H6).

## Changes
- Added `numbering` configuration section to `myst.yml`
- Disabled heading numbering for all six heading levels by setting each to `false`
  - `heading_1`, `heading_2`, `heading_3`, `heading_4`, `heading_5`, `heading_6`

## Details
This change prevents MyST from automatically numbering headings during document processing. This is useful when manual heading numbering is preferred or when the document structure should not include auto-generated heading numbers in the output.

https://claude.ai/code/session_01GzuT3fwak3NmcZMsRBVYGw